### PR TITLE
Add deny_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ $ luarocks make *.rockspec
 
 # Usage
 ## schema
-* allow_paths: The request path not match this path will forbidden with 403 code
-* regex: boolean, if true will use ngx.re.match to match the request_path and allow_paths, if false, Will strictly judge whether the two path are equal
+* allow_paths: if the request path not match this path will forbidden with 403 code
+* deny_paths: if the request path match this path will forbidden with 403 code
+* regex: boolean, if true will use ngx.re.match to match the request_path and allow_paths/deny_paths, if false, will strictly judge whether the two path are equal
 
 ## Example
 * create service
@@ -74,8 +75,26 @@ $ luarocks make *.rockspec
 {"message":"path not allowed"}
 ```
 
+* create kong-path-deny for route
+```
+  curl -X POST \
+  http://localhost:8001/routes/$routeId/plugins \
+  -H 'Content-Type: application/json' \
+  -d '{
+	"name":"kong-path-allow",
+	"config":{
+		"deny_":["/services/x"],
+		"regex":true
+	}}
+```
+* request /test/services/ will return the services object
+* request /test/services/x will now got 403 
+```
+{"message":"path not allowed"}
+```
 
-* trun the regex to false
+
+* turn the regex to false
 ```
 curl -X PATCH \
   http://localhost:8001/routes/$routeId/plugins/$pluginId \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kong-path-allow
-Determine if the path is in the path allow, if not, return 403
+Determine if a path is allowed, if not, return 403
 # Supporte kong version
 Kong >= 1.2
 # Install

--- a/kong-path-allow-0.1-3.rockspec
+++ b/kong-path-allow-0.1-3.rockspec
@@ -1,5 +1,5 @@
 package = "kong-path-allow"
-version = "0.1-2"
+version = "0.1-3"
 source = {
    url = "git+https://github.com/seifchen/kong-path-allow.git",
    branch = "master"

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -8,6 +8,7 @@ return {
         type = "record",
         fields = {
           { allow_paths = typedefs.paths},
+          { deny_paths = typedefs.paths },
           { regex = {
               type = "boolean",
               required = true,


### PR DESCRIPTION
This pretty self explanatory.

There are cases where is easier to deny only specific paths. This option allow this.

Note: there is a little subtlety in the logic,

if there is only allow_path stanza, then all paths not listed in the allow_paths are denied (default behaviour)
if there is only deny_path stanza, then all paths not listed in the deny_paths are allowed (new behaviour)

if there is both allow_paths and deny_paths, then a path should be in allow_path and *not* in deny_path to be allowed.

as a remark if you put the same path in both stanza it will be denied.