### PR TITLE
Fix plugin VERSION for Kong Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kong >= 1.2
 ### Select Version
 because this breaking changes with kong version within 2.* and 3.*.
 * If you use kong < 3.0 please use 0.1-3 or tag:v0.1.3
-* If you use kong >= 3.0 please use 0.2-0 or tag:v0.2.0
+* If you use kong >= 3.0 please use 0.2-1 or tag:v0.2.1
 ### Luarocks
 ```
 luarocks install kong-path-allow $version 

--- a/kong-path-allow-0.2-0.rockspec
+++ b/kong-path-allow-0.2-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-path-allow"
-version = "0.2-0"
+version = "0.2-1"
 source = {
    url = "git+https://github.com/seifchen/kong-path-allow.git",
    branch = "master"

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -3,7 +3,7 @@ local kong_meta     = require "kong.meta"
 local kongPathAllow = {}
 
 kongPathAllow.PRIORITY = 840
-kongPathAllow.VERSION = kong_meta.version
+kongPathAllow.VERSION = "0.2.1"
 local kong = kong
 local ngx = ngx
 local re_find = ngx.re.find


### PR DESCRIPTION
Updates `handler.lua`'s `VERSION` to align to the plugin's version and not the KongGW version.

Fixes #19

